### PR TITLE
Bootstrap Events page

### DIFF
--- a/events/2019.md
+++ b/events/2019.md
@@ -1,0 +1,138 @@
+# Presentations for the Year
+
+Find below a table of events for 2019 where a member of SRC has
+spoken or will speak, in chronological order.
+
+1. [Community RFCs for the Reason Ecosystem @ ReasonConf 🇦🇹](#community-rfcs-for-the-reason-ecosystem--reasonconf-vienna-)
+2. [Unreasonably Scalable Javascript @ Atlassian Engineering Nights 🇳🇱](#unreasonably-scalable-javascript--atlassian-engineering-nights-)
+2. [A Reasonable Web @ ReactConf Armenia 🇦🇲](#a-reasonable-web--reactconf-armenia-)
+2. [Building Web Apps like it's 1972 @ JSConf EU 🇩🇪](#building-web-apps-like-its-1972--jsconf-eu-)
+2. [Building Web Apps like it's 1972 @ BuzzConf 🇦🇷](#building-web-apps-like-its-1972--buzzconf-)
+
+## Community RFCs for the Reason Ecosystem @ ReasonConf 🇦🇹
+
+**Date**: April 13th
+
+**Sponsor**: SRC
+
+**Speaker**: @ostera
+
+**Recording**: Not yet published.
+
+**Type**: Open-stage lightning talk.
+
+**Summary**:
+
+As a community grows, the problem space its leaders handle increases drastically.
+In a programming language community, an influx of newcomers requires allocating
+resources to documentation writing, re-thinking developer flows, sponsoring 
+introductory events, and keeping things safe and sound with a code of conduct.
+
+But as the newcomers become the experts, the community itself will need tools to
+decide how to solve their biggest upcoming issues. Does the build system still
+make sense when building a cross-platform application? Do we require a particular
+syntax for this incredibly common idiom? Should we unify how we write and publish
+documentation?
+
+The Rust and Ember community have solved this with an RFC process, Python has 
+PEPs. Let's explore together how creating a low-overhead RFC process can empower
+the Reason Ecosystem to make important decisions for the benefit of everyone.
+
+## Unreasonably Scalable Javascript @ Atlassian Engineering Nights 🇳🇱
+
+**Link**: https://www.meetup.com/meetup-group-SiEXlasI/events/260923105/
+
+**Date**: May 19th
+
+**Sponsor**: SRC
+
+**Speaker**: @ostera
+
+**Summary**:
+
+As your Javascript programs scale in size and in complexity, it gets increasingly
+harder to keep development cycle and execution time short without sacrificing safety.
+
+More tests increase safety, but slow down cycle. More logic slow down your
+applications, and may increase the amount of tests!
+
+Join me in discovering how ReasonML can keep your team and your programs running
+at full speed, with blazing fast compilation and testing speeds, and the ability to,
+at any point, run natively.
+
+## A Reasonable Web @ ReactConf Armenia 🇦🇲
+
+**Link**: https://reactconf.am
+
+**Date**: May 25th
+
+**Sponsor**: SRC
+
+**Speaker**: @ostera
+
+**Summary**:
+
+We are fatigued. The amount of tools and frameworks and libraries we need to
+learn every keeps growing.
+
+We are confused. The amount of complexity put into each one of our tools,
+displayed by the sheer amount of configurations and features they pack, is hard
+to keep track of.
+
+And yet, we endure. We put up with the naysayers and raise to the challenge,
+StackOverflowing our way through work we deliver business value and make our
+clients happy.
+
+We are proud.
+
+What if I told you we could also be more productive? And less fatigued.
+Certainly also less confused. And endure less! And have more fun!
+
+What if I told you we can build a web that is reasonable to begin with? With
+laser-precision tooling that just does what you expect it to do, with minimal
+complexity overhead, with a welcoming community, with beautiful, pragmatic and
+productive abstractions.
+
+Let's learn about ReasonML, and build a more reasonable web together.
+
+
+## Building Web Apps like it's 1972 @ JSConf EU 🇩🇪
+
+**Link**: https://jsconf.eu
+
+**Date**: June 1st-2nd
+
+**Sponsor**: SRC
+
+**Speaker**: @ostera
+
+**Summary**:
+
+46 years have passed since the dawn of the Xerox Alto machine and its
+incredible UI and UX, brought straight from the future. Smalltalk,
+Message-passing, and a balanced mix of Functional and Object-oriented
+Programming made it all possible; a mix later to be quietly rediscovered as the
+Actor-model.
+
+Fast forward to today, and we find that the whole of the web seems to be stuck
+inbetween a global knowledge graph and a sandbox for interactive user
+experiences. Experiences that are limited by the technology that we have chosen
+to be ubiquitous.
+
+What can be learned from what we built over 4 decades ago? What are the
+lessons within Smalltalk, Erlang, Self, the Alto computer, and other
+achievements of the past? Let's explore together a world we owe cursors,
+dropdowns and windows to, and maybe learn along the way what it takes to bring
+new user experiences straight from the future!
+
+## Building Web Apps like it's 1972 @ BuzzConf 🇦🇷
+
+**Link**: https://buzzconf.org
+
+**Date**: June 1st-2nd
+
+**Sponsor**: SRC
+
+**Speaker**: @ostera
+
+**Summary**: [same as above](#building-web-apps-like-its-1972--jsconf-eu-)


### PR DESCRIPTION
Hello! @xaviervia had the greatest idea: we should collect all of the events that a SRC member has spoken at or will speak at.

The overall idea is to list conference talks (which are the main event type we currently have) chronologically, and put some info on them:

* link, and when it happenes
* who sponsored the talk? it's okay to put our employers here to make it obvious the talk was not in the scope of SRC
* a summary

I figured I might as well get the ball rolling with this PR. Feel free to commit directly to it, so we can get this up on the website sometime soon.

What do you think? 🙌 